### PR TITLE
capture t= parameter for youtube video start time

### DIFF
--- a/regex.js
+++ b/regex.js
@@ -27,7 +27,7 @@ const PAY_ANY_CURRENCY = /((((\d{1,8})?\.\d{1,8})|(\d{1,8}(\.\d{1,8})?))\s*[bB][
 const PAY_ANY_CURRENCY_BSV = /(((\d{1,8})?\.\d{1,8})|(\d{1,8}(\.\d{1,8})?))\s*[bB][sS][vV]/g;
 const PAY_ANY_CURRENCY_USD = /([$][\d]*(\.[\d]+)?)/g;
 /* eslint-disable */
-const YOUTUBE_REGEX = /http(?:s?):\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(&(amp;)?‌​[\w\?‌​=]*)?/;
+const YOUTUBE_REGEX = /http(?:s?):\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)(?<videoID>[\w\-\_]*)(&(amp;)?[\w\?=]*)?(?:\?)(?:(?:.{0,}&{0,})t=(?<start>[0-9]{1,}))?/;
 /* eslint-enable */
 
 const match = (value, option) => {


### PR DESCRIPTION
This will capture videoID and start time into named capture groups regardless of parameter order.
If you don't want to use named capture groups, you can remove `?<videoID>` and `?<start>` from the regex. Named capture group support table is here: https://caniuse.com/#feat=mdn-javascript_builtins_regexp_named_capture_groups
<img width="1397" alt="Screen Shot 2020-08-25 at 9 52 19 AM" src="https://user-images.githubusercontent.com/456719/91183313-53f31800-e6b9-11ea-98ad-c5170ba15272.png">
