### PR TITLE
fixed regex for capture videoID and start time

### DIFF
--- a/regex.js
+++ b/regex.js
@@ -27,7 +27,7 @@ const PAY_ANY_CURRENCY = /((((\d{1,8})?\.\d{1,8})|(\d{1,8}(\.\d{1,8})?))\s*[bB][
 const PAY_ANY_CURRENCY_BSV = /(((\d{1,8})?\.\d{1,8})|(\d{1,8}(\.\d{1,8})?))\s*[bB][sS][vV]/g;
 const PAY_ANY_CURRENCY_USD = /([$][\d]*(\.[\d]+)?)/g;
 /* eslint-disable */
-const YOUTUBE_REGEX = /http(?:s?):\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(&(amp;)?‌​[\w\?‌​=]*)?/;
+const YOUTUBE_REGEX = /http(?:s?):\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)(?<videoID>[^#&?]*)(?:.*(?>t=(?<start>[0-9]+)).*$)?/;
 /* eslint-enable */
 
 const match = (value, option) => {


### PR DESCRIPTION
This one is capturing as before but also regular links.
<img width="1394" alt="Screen Shot 2020-08-25 at 11 29 22 AM" src="https://user-images.githubusercontent.com/456719/91194581-485a1e00-e6c6-11ea-9e8f-b54f2356afbd.png">
<img width="1387" alt="Screen Shot 2020-08-25 at 11 29 14 AM" src="https://user-images.githubusercontent.com/456719/91194590-4abc7800-e6c6-11ea-8b22-451dffd600b0.png">
